### PR TITLE
Sublime Command Palette support

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,0 +1,7 @@
+[
+    {
+        "caption": "FormatSQL: Format SQL statement",
+        "command": "format_sql"
+    }
+]
+


### PR DESCRIPTION
Hi,

This patch adds "Format SQL statement" command to Sublime Command Palette (reachable via cmd+shift+P).

Can you please apply this patch if you don't mind SublimeFormatSQL to be accessible though Sublime Command Palette?

Kind regards,
z4y4ts
